### PR TITLE
fix invalid index in array compare

### DIFF
--- a/includes/class-piklist.php
+++ b/includes/class-piklist.php
@@ -2302,7 +2302,7 @@ class Piklist
    */
   public static function sort_by_args_order($a, $b)
   {
-    if (!isset($a['args']['order']) && !isset($b['args']['order']))
+    if (!isset($a['args']['order']) || !isset($b['args']['order']))
     {
       return 0;
     }


### PR DESCRIPTION
- was seeing error about invalid index "order"; this happened when one of the two array elements being compared didn't have an ['args']['order'] element
- the code was returning zero only if both were not set
- changed && to || so that if either is not set, return value is 0