### PR TITLE
Fixed bug causing group addmore fields to not be reducable in size

### DIFF
--- a/includes/class-piklist-validate.php
+++ b/includes/class-piklist-validate.php
@@ -434,6 +434,20 @@ class Piklist_Validate
           {
             $paths = piklist::array_paths($field['request_value']);
 
+            // Do not attempt to process any previously present fields that have been removed from the submitted data
+            foreach( array_keys( $fields ) as $field_key )
+            {
+                // Make sure this is a key for a field in the current group
+                if ( substr( $field_key, 0, strlen( $field['field'] ) + 1 ) == $field['field'] . ':' )
+                {
+                    $_path = substr( $field_key, strlen( $field['field'] ) + 1 );
+                    if ( ! in_array( $_path, $paths ) )
+                    {
+                        unset( $fields[ $field_key ] );
+                    }
+                }
+            }
+
             foreach ($paths as $path)
             {
               $path = explode(':', $path);


### PR DESCRIPTION
When you have a group field with the add-more option set, the fields that
are being processed will be adjusted according to the actual submitted amount
of fields so that groups can actually be removed.

Ref https://piklist.com/support/topic/bug-with-group-addmore/