### PR TITLE
fix Non-Piklist custom fields are missing from the dropdown in standa…

### DIFF
--- a/includes/class-piklist-cpt.php
+++ b/includes/class-piklist-cpt.php
@@ -1281,8 +1281,10 @@ class Piklist_CPT
     {
       $meta_keys = array();
 
-      foreach ($fields['post_meta'] as $meta_key => $field)
+      foreach ($fields['post_meta'] as $post_meta => $field)
       {
+      	$meta_key = $field['field'];
+
         if (!strstr($meta_key, ':') && !$field['display'] && $field['type'] != 'group')
         {
           array_push($meta_keys, $meta_key);


### PR DESCRIPTION
BUG: https://github.com/piklist/piklist/issues/9

Old code was saving the numeric array key, not the actual meta_key. 

IMPORTANT: users effected with this bug will need to delete the "piklist_post_meta_keys" field in their _options table.