### PR TITLE
Fix empty shortcut editor when on Windows server

### DIFF
--- a/includes/class-piklist-add-on.php
+++ b/includes/class-piklist-add-on.php
@@ -218,13 +218,20 @@ class Piklist_Add_On
   public static function current()
   {
     $backtrace = debug_backtrace();
-    
     foreach ($backtrace as $trace)
     {
-      if (strstr($trace['file'], '/parts/'))
+      if (!isset($trace['file'])) 
       {
-        $add_on = substr($trace['file'], 0, strpos($trace['file'], '/parts/'));
-        $add_on = substr($add_on, strrpos($add_on, '/') + 1);
+          continue;
+      }
+      
+      $file = $trace['file'];
+      $parts = DIRECTORY_SEPARATOR . "parts" . DIRECTORY_SEPARATOR;
+      
+      if (strstr($file, $parts))
+      {
+        $add_on = substr($file, 0, strpos($file, $parts));
+        $add_on = substr($add_on, strrpos($add_on, DIRECTORY_SEPARATOR) + 1);
 
         if (isset(piklist::$add_ons[$add_on]))
         {

--- a/includes/class-piklist-shortcode.php
+++ b/includes/class-piklist-shortcode.php
@@ -238,12 +238,16 @@ class Piklist_Shortcode
   {
     if (self::$shortcodes[$tag])
     {
-      foreach ($attributes as $attribute => $attribute_value)
+      if (!empty($attributes))
       {
-        if (stristr($attribute_value, '%'))
-        {
-          $attributes[$attribute] = stripslashes(rawurldecode($attribute_value));
-        }
+          
+          foreach ($attributes as $attribute => $attribute_value)
+          {
+            if (stristr($attribute_value, '%'))
+            {
+              $attributes[$attribute] = stripslashes(rawurldecode($attribute_value));
+            }
+          }
       }
 
       ob_start();
@@ -252,7 +256,10 @@ class Piklist_Shortcode
 
       if (self::$shortcodes[$tag]['render'])
       {
-        $attributes['content'] = $content;
+        if (isset($attributes['content'])) 
+        {
+          $attributes['content'] = $content;
+        }
         
         foreach (self::$shortcodes[$tag]['render'] as $render)
         {


### PR DESCRIPTION
Under Windows, debug_backtrace() returns paths with backslashes. Added
code to normalize so function works and shortcode editor does not break. #18 

Also added fix for #20 (when using shortcuts with no arguments or content)