### PR TITLE
Add support for github-updater plugin

### DIFF
--- a/piklist.php
+++ b/piklist.php
@@ -9,6 +9,7 @@ Author URI: http://piklist.com
 Text Domain: piklist
 Domain Path: /languages
 License: GPLv2
+GitHub Plugin URI: https://github.com/piklist/piklist
 */
 
 /*


### PR DESCRIPTION
With this change users of Piklist can directly update to most current branches from Github.