### PR TITLE
Update relate query support to WordPress 4.7 standards

### DIFF
--- a/add-ons/piklist-demos/piklist-demos.php
+++ b/add-ons/piklist-demos/piklist-demos.php
@@ -30,6 +30,8 @@ Domain Path: /languages
       ,'title' => __('Enter a new Demo Title')
       ,'menu_icon' => piklist('url', 'piklist') . '/parts/img/piklist-menu-icon.svg'
       ,'page_icon' => piklist('url', 'piklist') . '/parts/img/piklist-page-icon-32.png'
+      ,'show_in_rest' => true
+      ,'rest_base' => 'piklist-demos'
       ,'supports' => array(
         'title'
         ,'post-formats'
@@ -53,7 +55,11 @@ Domain Path: /languages
         ,'author'
       )
       ,'status' => array(
-        'new' => array(
+        'publish' => array(
+          'label' => 'Publish'
+          ,'public' => true
+        )
+        ,'new' => array(
           'label' => 'New'
           ,'public' => false
         )


### PR DESCRIPTION
The way additional query parameters are supported were changed when the REST API was merged into core in 4.7. This begins to fix that issue and so far allows for `post_has` and `post_belongs` to be used in the query.

Important Note: The `relate_query` parameter was not added on purpose. It's easy to sanitize `post_has` and `post_belongs`, but `relate_query` is a complex collection. Furthermore, it's worth considering that if something more complex is needed, the developer at that time should probably make their own query var that builds the `relate_query` itself. This reduces the complexity of the query and improves security.

I'm very interested in anyones thoughts that would like to chime in.