### PR TITLE
minor bug fix, for custom created folders in the part folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ $RECYCLE.BIN/
 /.idea/
 
 # Eclipse
+.buildpath
+/.settings/
 *.pydevproject
 .project
 .metadata

--- a/includes/class-piklist.php
+++ b/includes/class-piklist.php
@@ -525,7 +525,7 @@ class Piklist
     }
     else
     {
-      if (dirname($view) != str_replace('/.php', '', $view))
+      if (dirname($view) != str_replace('.php', '', $view))
       {
         trigger_error(sprintf(__('File does not exist%s', 'piklist'), ': ' . $view), E_USER_WARNING);
       }


### PR DESCRIPTION
If someone create a custom folder inside the parts folder there will be a warning; "File does not exist .php"
The problem was a small typo, I think.
 I changed '/.php' into '.php' so the files can be accessed as any other file..

Regards,

Tonny