### PR TITLE
Fix ability to add submenu pages in WooCommerce

### DIFF
--- a/includes/class-piklist-admin.php
+++ b/includes/class-piklist-admin.php
@@ -83,7 +83,7 @@ class Piklist_Admin
 
     add_action('admin_head', array('piklist_admin', 'admin_head'));
     add_action('wp_head', array('piklist_admin', 'admin_head'));
-    add_action('admin_menu', array('piklist_admin', 'register_admin_pages'), -1);
+    add_action('admin_menu', array('piklist_admin', 'register_admin_pages'));
     add_action('redirect_post_location', array('piklist_admin', 'redirect_post_location'), 10, 2);
 
     add_filter('admin_footer_text', array('piklist_admin', 'admin_footer_text'));


### PR DESCRIPTION
WooCommerce does something fancy where the parent url of the submenu items to the WooCommerce menu is 'woocommerce'. So they're doing something fancy in the admin_menu chain.

Currently we're hooking into -1, which is very likely happening before the hook. By removing that and letting the menu fall back on the default of 10 everything starts working.

I'm not aware of any reason why a priority of -1 was used. I know priorities in Piklist used to be more of a delicate balance, but I believe things are more robust, now.

Any issues with this? I can see others wanting to set custom setting pages inside the WooCommerce menu.