### PR TITLE
update piklist_admin::$piklist_dependent to store dependent theme and plugins

### DIFF
--- a/includes/class-piklist-add-on.php
+++ b/includes/class-piklist-add-on.php
@@ -46,10 +46,10 @@ class Piklist_Add_On
     require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
     $site_wide_plugins = get_site_option('active_sitewide_plugins');
-    
+
     $plugins = get_option('active_plugins');
     $plugins = $plugins ? $plugins : array();
-    
+
     if (!empty($site_wide_plugins))
     {
       $plugins = array_merge($plugins, array_keys($site_wide_plugins));
@@ -62,7 +62,8 @@ class Piklist_Add_On
       if (file_exists($path))
       {
         $data = piklist::get_file_data($path, array(
-                  'type' => 'Plugin Type'
+                   'name' => 'Plugin Name'
+                  ,'type' => 'Plugin Type'
                   ,'version' => 'Version'
                 ));
 
@@ -72,7 +73,7 @@ class Piklist_Add_On
 
           add_action('load-plugins.php', array('piklist_admin', 'deactivation_link'));
 
-          piklist_admin::$piklist_dependent = true;
+          piklist_admin::$piklist_dependent['plugins'][] = $data;
 
           if ($data['version'])
           {

--- a/includes/class-piklist-admin.php
+++ b/includes/class-piklist-admin.php
@@ -15,10 +15,10 @@ if (!defined('ABSPATH')) exit; // Exit if accessed directly
 class Piklist_Admin
 {
   /**
-   * @var bool Whether a theme is Piklist dependent.
+   * @var bool Stores all dependent plugins and theme
    * @access public
    */
-  public static $piklist_dependent = false;
+  public static $piklist_dependent = array();
 
   /**
    * @var bool Whether Piklist is network activated.
@@ -602,7 +602,7 @@ class Piklist_Admin
   {
     unset($actions['deactivate']);
 
-    array_unshift($actions, sprintf(__('%1$sDependent plugins or theme are active.%2$s', 'piklist'), '<div style="color:#a00">', piklist_admin::replace_deactivation_link_help() .'</div>') . (is_network_admin() ? __('Network Deactivate', 'piklist') :  __('Deactivate', 'piklist')));
+    array_unshift($actions, sprintf(__('%1$sDependent plugins or theme are active.%2$s', 'piklist'), '<div style="color:#a00"><a href="admin.php?page=piklist">', piklist_admin::replace_deactivation_link_help() .'</a></div>') . (is_network_admin() ? __('Network Deactivate', 'piklist') :  __('Deactivate', 'piklist')));
 
     return $actions;
   }

--- a/includes/class-piklist-theme.php
+++ b/includes/class-piklist-theme.php
@@ -88,7 +88,11 @@ class Piklist_Theme
 
       add_action('load-plugins.php', array('piklist_admin', 'deactivation_link'));
 
-      piklist_admin::$piklist_dependent = true;
+      $current_theme = wp_get_theme();
+      if ( $current_theme->exists() )
+      {
+          piklist_admin::$piklist_dependent[theme][] = $current_theme->get( 'Name' );	  
+      }
     }
 
     if (get_template_directory() != get_stylesheet_directory() && is_dir(get_template_directory() . '/piklist'))
@@ -97,7 +101,7 @@ class Piklist_Theme
         'path' => get_template_directory() . '/piklist'
         ,'url' => get_template_directory_uri() . '/piklist'
       );
-      
+
       piklist::$paths['parent-theme'] = &piklist::$add_ons['parent-theme']['path'];
     }
   }

--- a/parts/admin-pages/welcome.php
+++ b/parts/admin-pages/welcome.php
@@ -15,6 +15,50 @@ Page: piklist
   <?php printf(__('Version %s', 'piklist'), piklist::$version); ?>
 </div>
 
+<?php if (!empty(piklist_admin::$piklist_dependent)): ?>
+
+    <div class="dependent-on-piklist">
+
+        <h3><?php _e('Currently Powered by Piklist on', 'piklist'); ?> <?php echo get_bloginfo('name');?></h2>
+
+            <?php $dependencies = piklist_admin::$piklist_dependent; ?>
+
+            <?php foreach ($dependencies as $type => $item): ?>
+
+                <?php if($type == 'theme') : ?>
+
+                    <p>
+
+                        <strong><?php _e('Active Theme', 'piklist');?></strong>: <?php echo ($item[0]);?>
+
+                    </p>
+
+                <?php endif;?>
+
+                <?php if($type == 'plugins') : ?>
+
+                    <p>
+
+                        <?php foreach ($item as $key => $value) : ?>
+
+                            <?php $plugin_list[] = $value['name']; ?>
+
+                        <?php endforeach;?>
+
+                        <strong><?php _e('Active Plugins', 'piklist');?></strong> : <?php echo implode(', ', $plugin_list); ?>
+
+                    </p>
+
+                <?php endif; ?>
+
+            <?php endforeach; ?>
+
+    </div>
+
+<?php endif; ?>
+
+
+
 <div class="piklist-social-links">
   <a class="facebook_link" href="http://facebook.com/piklist">
     <span class="dashicons dashicons-facebook-alt"></span>
@@ -27,11 +71,11 @@ Page: piklist
   </a>
 </div><!-- .piklist-social-links -->
 
-<div class="changelog">
+<div class="section">
   <h2 class="about-headline-callout"><?php _e('Now even more powerful than before.','piklist'); ?></h2>
 </div>
 
-<div class="changelog">
+<div class="section">
   <div class="feature-section col two-col">
     <div>
       <h3><?php _e('Post relationships', 'piklist');?></h3>
@@ -46,7 +90,7 @@ Page: piklist
 
 
 
-<div class="changelog">
+<div class="section">
   <div class="feature-section col two-col">
     <div class="alt-feature">
       <h3><?php _e('Add mores');?></h3>
@@ -61,7 +105,7 @@ Page: piklist
 
 
 
-<div class="changelog">
+<div class="section">
   <div class="feature-section col two-col">
     <div>
       <h3><?php _e('WorkFlows','piklist');?></h3>
@@ -76,7 +120,7 @@ Page: piklist
 
 
 
-<div class="changelog">
+<div class="section">
   <div class="feature-section col two-col">
     <div class="alt-feature">
       <h3><?php _e('Multiple user roles','piklist');?></h3>
@@ -91,7 +135,7 @@ Page: piklist
 
 
 
-<div class="changelog">
+<div class="section">
   <h2 class="about-headline-callout"><?php _e('Intelligent field system','piklist');?></h2>
   <p class="about-description"><?php _e('Easily create powerful fields just the way you want... and place them wherever you want.','piklist');?></p>
 
@@ -130,7 +174,7 @@ Page: piklist
 
 
 
-<div class="changelog">
+<div class="section">
   <h2 class="about-headline-callout"><?php _e('Customize everything in WordPress.','piklist');?></h2>
   <p class="about-description"><?php _e('Post Types, Taxonomies, User Profiles, Settings, Admin Pages, Widgets, Dashboard, Contextual Help, and more...','piklist');?></p>
 
@@ -203,7 +247,7 @@ Page: piklist
 
 
 
-<div class="changelog">
+<div class="section">
   <div class="feature-section col three-col">
     <div class="col-1">
       <h2 class="about-headline-callout"><?php _e('Get Started','piklist');?></h2>
@@ -328,7 +372,8 @@ var addthis_config = {"data_track_addressbar":false};</script>
 
 <style type="text/css">
 
-  html {
+  html,
+  #wpcontent {
     background-color: #fff;
   }
 
@@ -350,8 +395,13 @@ var addthis_config = {"data_track_addressbar":false};</script>
   }
 
   img.screenshot {
-    width: 95%;
+    width: 75%;
   }
+
+  .section {
+      padding: 10px 0;
+  }
+
 
   .icon16.icon-comments:before {
     font-size: 40px;
@@ -360,7 +410,7 @@ var addthis_config = {"data_track_addressbar":false};</script>
 
   .piklist-badge {
     color: #DD3726;
-    background: url('<?php echo piklist::$add_ons['piklist']['url']; ?>/parts/img/piklist-logo.png') no-repeat center 0px #fff !important;
+    background: url('<?php echo piklist::$add_ons['piklist']['url']; ?>/parts/img/piklist-logo.png') no-repeat center 0px transparent !important;
     margin-top: 0;
     padding-top: 85px;
     display: inline-block;
@@ -468,11 +518,27 @@ var addthis_config = {"data_track_addressbar":false};</script>
     font-size: 22px;
   }
 
+  .about-wrap .feature-section.col .last-feature {
+      margin-bottom: 0px;
+  }
+
+  .dependent-on-piklist {
+      text-align: center;
+      border-top: 1px solid #000;
+      border-bottom: 1px solid #000;
+      padding: 10px 0;
+      margin-bottom: 20px;
+  }
+
+  .dependent-on-piklist h3 {
+      margin: 0;
+  }
+
   @media (max-width: 782px) {
 
     html,
     #wpwrap {
-      background-color: #fff;
+      background-color: transparent;
     }
 
     .about-wrap .feature-section.two-col > div.alt-feature {


### PR DESCRIPTION
ISSUE: When Piklist has dependent plugins or theme, we disable the "deactivate" link on the plugin. This has caused lots of confusion, even though we show a message: "Dependent plugins or theme are active."

UPDATES: This PR does a few  things:
1) Change piklist_admin::$piklist_dependent to an array that will store the names of the dependent plugins or theme.

2) Update the welcome.php to show the dependencies list if available.

3) Make the message "Dependent plugins or theme are active." a link to the Welcome page  listing the dependencies.


<img width="335" alt="screenshot 2018-01-03 23 36 56" src="https://user-images.githubusercontent.com/154488/34550458-1b69a3aa-f0df-11e7-8a22-e869d0d353ff.png">
<img width="1063" alt="screenshot 2018-01-03 23 36 36" src="https://user-images.githubusercontent.com/154488/34550459-1b79a732-f0df-11e7-8243-b041e987abbd.png">






