### PR TITLE
Added a filter to allow setting custom field aliases

### DIFF
--- a/includes/class-piklist-form.php
+++ b/includes/class-piklist-form.php
@@ -314,6 +314,14 @@ class Piklist_Form
      */
     self::$field_list_types = apply_filters('piklist_field_list_types', self::$field_list_types);
 
+    /**
+     * piklist_field_alias
+     * Add custom aliases to the default aliases.
+     *
+     * @since 1.0
+     */
+    self::$field_alias = apply_filters('piklist_field_alias', self::$field_alias);
+
     foreach (self::$template_shortcodes as $template_shortcode)
     {
       add_shortcode($template_shortcode, array('piklist_form', 'template_shortcode'));


### PR DESCRIPTION
Right now there is no way to add custom field aliases, so I added a filter to do that, in a similar way to what you do with field_list_types
