### PR TITLE
Fix validation with add more fields

### DIFF
--- a/includes/class-piklist-form.php
+++ b/includes/class-piklist-form.php
@@ -314,14 +314,6 @@ class Piklist_Form
      */
     self::$field_list_types = apply_filters('piklist_field_list_types', self::$field_list_types);
 
-    /**
-     * piklist_field_alias
-     * Add custom fields to the list types object.
-     *
-     * @since 1.0
-     */
-    self::$field_alias = apply_filters('piklist_field_alias', self::$field_alias);
-
     foreach (self::$template_shortcodes as $template_shortcode)
     {
       add_shortcode($template_shortcode, array('piklist_form', 'template_shortcode'));

--- a/includes/class-piklist-form.php
+++ b/includes/class-piklist-form.php
@@ -314,6 +314,14 @@ class Piklist_Form
      */
     self::$field_list_types = apply_filters('piklist_field_list_types', self::$field_list_types);
 
+    /**
+     * piklist_field_alias
+     * Add custom aliases to the default aliases.
+     *
+     * @since 1.0
+     */
+    self::$field_alias = apply_filters('piklist_field_alias', self::$field_alias);
+
     foreach (self::$template_shortcodes as $template_shortcode)
     {
       add_shortcode($template_shortcode, array('piklist_form', 'template_shortcode'));

--- a/includes/class-piklist-form.php
+++ b/includes/class-piklist-form.php
@@ -314,14 +314,6 @@ class Piklist_Form
      */
     self::$field_list_types = apply_filters('piklist_field_list_types', self::$field_list_types);
 
-    /**
-     * piklist_field_alias
-     * Add custom aliases to the default aliases.
-     *
-     * @since 1.0
-     */
-    self::$field_alias = apply_filters('piklist_field_alias', self::$field_alias);
-
     foreach (self::$template_shortcodes as $template_shortcode)
     {
       add_shortcode($template_shortcode, array('piklist_form', 'template_shortcode'));

--- a/includes/class-piklist-form.php
+++ b/includes/class-piklist-form.php
@@ -314,6 +314,14 @@ class Piklist_Form
      */
     self::$field_list_types = apply_filters('piklist_field_list_types', self::$field_list_types);
 
+    /**
+     * piklist_field_alias
+     * Add custom fields to the list types object.
+     *
+     * @since 1.0
+     */
+    self::$field_alias = apply_filters('piklist_field_alias', self::$field_alias);
+
     foreach (self::$template_shortcodes as $template_shortcode)
     {
       add_shortcode($template_shortcode, array('piklist_form', 'template_shortcode'));

--- a/includes/class-piklist-validate.php
+++ b/includes/class-piklist-validate.php
@@ -210,6 +210,7 @@ class Piklist_Validate
             else
             {
               $errors = array();
+              $error_indexes_per_field = array();
 
               self::$form_submission = $check['fields_data'];
 
@@ -220,12 +221,14 @@ class Piklist_Validate
                   if ($field['errors'])
                   {
                     array_push($errors, $field['name']);
+                    $error_indexes_per_field[$field['name']] = array_keys($field['errors']);
                   }
                 }
               }
 
               wp_send_json_error(array(
                 'errors' => $errors
+                ,'error_indexes_per_field' => $error_indexes_per_field
                 ,'notice' => self::notices(null, true)
               ));
             }
@@ -725,11 +728,13 @@ class Piklist_Validate
 
       foreach ($field['request_value'] as $request_value)
       {
-        $validation_result = call_user_func_array($validation['callback'], array($index, $request_value, $options, $field, $fields_data));
+        if ($field['request_value'][$index]) {
+          $validation_result = call_user_func_array($validation['callback'], array($index, $request_value, $options, $field, $fields_data));
 
-        if ($validation_result !== true)
-        {
-          $field = self::add_error($field, $index, !empty($validation['message']) ? $validation['message'] : (is_string($validation_result) ? $validation_result : __('is not valid input', 'piklist')));
+          if ($validation_result !== true)
+          {
+            $field = self::add_error($field, $index, !empty($validation['message']) ? $validation['message'] : (is_string($validation_result) ? $validation_result : __('is not valid input', 'piklist')));
+          }
         }
 
         $index++;

--- a/parts/js/piklist.js
+++ b/parts/js/piklist.js
@@ -883,7 +883,10 @@
                     input.parents('.wp-editor-wrap:eq(0)').addClass('piklist-error');
                   }
 
-                  input.addClass('piklist-error');
+                  for (var idx = 0; idx < response.data.error_indexes_per_field[field_name].length; idx++) 
+                  {
+                    $(input[response.data.error_indexes_per_field[field_name][idx]]).addClass('piklist-error');
+                  }
                 }
               }
 


### PR DESCRIPTION
This fixes this issue:

https://github.com/piklist/piklist/issues/60

In the method validate_value_callback, if the $field['request_value'] is not an array, the code performs an if ($field['request_value']) before running validation. For add-more fields however, the code goes straight to perform the validation. So I changed this behaviour.

This makes the code work, but the code on the client side for current add more fields, marks all inputs from the add more field are as wrong even only one of them is wrong. The current validation code stores the information about the index that failed, so I passed it to the client side and updated the javascript code to use that information.

Now it seems to work fine. Please take a look and tell me something about it! Thanks.
