### PR TITLE
Comment block updates

### DIFF
--- a/includes/class-piklist-help.php
+++ b/includes/class-piklist-help.php
@@ -49,6 +49,8 @@ class Piklist_Help
               ,'post_format' => 'Post Format'
               ,'setting' => 'Setting'
               ,'taxonomy' => 'Taxonomy'
+              ,'id' => 'ID'
+              ,'slug' => 'Slug'
             );
 
     piklist::process_parts('help', $data, array('piklist_help', 'register_help_callback'));

--- a/includes/class-piklist-media.php
+++ b/includes/class-piklist-media.php
@@ -109,6 +109,7 @@ class Piklist_Media
               ,'order' => 'Order'
               ,'new' => 'New'
               ,'id' => 'ID'
+              ,'slug' => 'Slug'
             );
 
     piklist::process_parts('media', $data, array('piklist_media', 'register_meta_boxes_callback'));

--- a/includes/class-piklist-meta.php
+++ b/includes/class-piklist-meta.php
@@ -167,6 +167,7 @@ class Piklist_Meta
               ,'status' => 'Status'
               ,'new' => 'New'
               ,'id' => 'ID'
+              ,'slug' => 'Slug'
               ,'template' => 'Template'
               ,'meta_box' => 'Meta Box'
               ,'post_format' => 'Post Format'

--- a/includes/class-piklist-notice.php
+++ b/includes/class-piklist-notice.php
@@ -61,8 +61,10 @@ class Piklist_Notice
               ,'role' => 'Role'
               ,'page' => 'Page'
               ,'dismiss' => 'Dismiss'
+              ,'id' => 'ID'
+              ,'slug' => 'Slug'
             );
-            
+
     piklist::process_parts('notices', $data, array('piklist_notice', 'register_notice_callback'));
   }
 

--- a/includes/class-piklist-pointer.php
+++ b/includes/class-piklist-pointer.php
@@ -74,8 +74,10 @@ class Piklist_Pointer
               ,'anchor_id' => 'Anchor ID'
               ,'edge' => 'Edge'
               ,'align' => 'Align'
+              ,'id' => 'ID'
+              ,'slug' => 'Slug'
             );
-            
+
     piklist::process_parts('pointers', $data, array('piklist_pointer', 'register_pointer_callback'));
   }
 

--- a/includes/class-piklist-taxonomy.php
+++ b/includes/class-piklist-taxonomy.php
@@ -171,6 +171,8 @@ class Piklist_Taxonomy
               ,'order' => 'Order'
               ,'taxonomy' => 'Taxonomy'
               ,'new' => 'New'
+              ,'id' => 'ID'
+              ,'slug' => 'Slug'
             );
 
     piklist::process_parts('terms', $data, array('piklist_taxonomy', 'register_meta_boxes_callback'));

--- a/includes/class-piklist-user.php
+++ b/includes/class-piklist-user.php
@@ -76,6 +76,8 @@ class Piklist_User
               ,'order' => 'Order'
               ,'role' => 'Role'
               ,'new' => 'New'
+              ,'id' => 'ID'
+              ,'slug' => 'Slug'
             );
 
     piklist::process_parts('users', $data, array('piklist_user', 'register_meta_boxes_callback'));

--- a/includes/class-piklist-workflow.php
+++ b/includes/class-piklist-workflow.php
@@ -144,6 +144,7 @@ class Piklist_Workflow
               ,'taxonomy' => 'Taxonomy'
               ,'template' => 'Template'
               ,'id' => 'ID'
+              ,'slug' => 'Slug'
               ,'role' => 'Role'
               ,'redirect' => 'Redirect'
               ,'header' => 'Header'

--- a/includes/class-piklist.php
+++ b/includes/class-piklist.php
@@ -1079,9 +1079,24 @@ class Piklist
   {
     global $post, $pagenow, $current_screen;
 
+    $validate_object = null;
+
     if (is_null($post) && isset($_GET['action']) && 'edit' === $_GET['action'] && !empty($_GET['post']))
     {
       $post = get_post($_GET['post']);
+      $validate_object = 'post';
+    }
+
+    if ( $pagenow == 'term.php' )
+    {
+      $term = get_term_by('id',$_GET['tag_ID'], $_GET['taxonomy']);
+      $validate_object = 'term';
+    }
+
+    if ( $pagenow == 'user-edit.php' )
+    {
+      $user = get_user_by('id',$_GET['user_id']);
+      $validate_object = 'user';
     }
 
     switch ($parameter)
@@ -1143,13 +1158,37 @@ class Piklist
 
       case 'id':
 
-        return $post && in_array($post->ID, $value);
+        switch ($validate_object) {
+          case 'post':
+            return $post && in_array($post->ID, $value);
+          break;
+
+          case 'term':
+            return $term && in_array($term->term_id, $value);
+          break;
+
+          case 'user':
+            return $user && in_array($user->ID, $value);
+          break;
+        }
 
       break;
 
       case 'slug':
 
-        return $post && in_array($post->post_name, $value);
+        switch ($validate_object) {
+          case 'post':
+            return $post && in_array($post->post_name, $value);
+          break;
+
+          case 'term':
+            return $term && in_array($term->slug, $value);
+          break;
+
+          case 'user':
+            return $user && in_array(strtolower($user->data->user_login), $value);
+          break;
+        }
 
       break;
 

--- a/includes/class-piklist.php
+++ b/includes/class-piklist.php
@@ -954,6 +954,7 @@ class Piklist
       {
         case 'capability':
         case 'id':
+        case 'slug':
         case 'page':
         case 'post_type':
         case 'role':
@@ -1146,6 +1147,12 @@ class Piklist
 
       break;
 
+      case 'slug':
+
+        return $post && in_array($post->post_name, $value);
+
+      break;
+
       case 'template':
 
         if (!$post)
@@ -1228,12 +1235,12 @@ class Piklist
     return $folders;
   }
 
-	/**
+  /**
    * pre
    * Used for debugging to output information to the screen.
    *
    * @param mixed $output Information to output.
-	 * @param $display Output to screen or just source.
+   * @param $display Output to screen or just source.
    *
    * @access public
    * @static
@@ -1243,7 +1250,7 @@ class Piklist
   {
     $output = $output === '-' ? '--------------------------------------------------' : $output;
 
-		$display = $display === false ? 'style="display:none;"' : '';
+    $display = $display === false ? 'style="display:none;"' : '';
 
     echo "<pre $display>\r\n";
 
@@ -1531,18 +1538,18 @@ class Piklist
       ,'menu_name' => $plural
     );
 
-		/**
-		 * piklist_post_type_labels_locale
-		 * Pass an array of labels for a Post Type
-		 *
-		 * Allows you to create new labels for an already registered Post Type that uses piklist('post_type_labels')
-		 * Primarily used for non-Engish locales
-		 *
-		 * @param array $labels
-		 * @param array $locale
-		 *
-		 * @since 1.0
-		 */
+    /**
+     * piklist_post_type_labels_locale
+     * Pass an array of labels for a Post Type
+     *
+     * Allows you to create new labels for an already registered Post Type that uses piklist('post_type_labels')
+     * Primarily used for non-Engish locales
+     *
+     * @param array $labels
+     * @param array $locale
+     *
+     * @since 1.0
+     */
     return apply_filters('piklist_post_type_labels_locale', $labels, $locale);
   }
 
@@ -1594,18 +1601,18 @@ class Piklist
       ,'name_admin_bar' => $label
     );
 
-		/**
-		 * piklist_taxonomy_labels_locale
-		 * Pass an array of labels for a Taxonomy
-		 *
-		 * Allows you to create new labels for an already registered Taxonomy that uses piklist('taxoomy_labels')
-		 * Primarily used for non-Engish locales
-		 *
-		 * @param array $labels
-		 * @param array $locale
-		 *
-		 * @since 1.0
-		 */
+    /**
+     * piklist_taxonomy_labels_locale
+     * Pass an array of labels for a Taxonomy
+     *
+     * Allows you to create new labels for an already registered Taxonomy that uses piklist('taxoomy_labels')
+     * Primarily used for non-Engish locales
+     *
+     * @param array $labels
+     * @param array $locale
+     *
+     * @since 1.0
+     */
     return apply_filters('piklist_taxonomy_labels_locale', $labels, $locale);
   }
 

--- a/includes/class-piklist.php
+++ b/includes/class-piklist.php
@@ -1079,7 +1079,7 @@ class Piklist
   {
     global $post, $pagenow, $current_screen;
 
-    $validate_object = null;
+    $validate_object = 'post';
 
     if (is_null($post) && isset($_GET['action']) && 'edit' === $_GET['action'] && !empty($_GET['post']))
     {
@@ -1089,13 +1089,13 @@ class Piklist
 
     if ( $pagenow == 'term.php' )
     {
-      $term = get_term_by('id',$_GET['tag_ID'], $_GET['taxonomy']);
+      $term = get_term_by('id', $_GET['tag_ID'], $_GET['taxonomy']);
       $validate_object = 'term';
     }
 
     if ( $pagenow == 'user-edit.php' )
     {
-      $user = get_user_by('id',$_GET['user_id']);
+      $user = get_user_by('id', $_GET['user_id']);
       $validate_object = 'user';
     }
 


### PR DESCRIPTION
This PR extends the "ID" parameter in the Piklist comment blocks so other individual parts can be targeted, in addition to a page. It also adds the "Slug" parameter for targeting of an individual page, term, user, help, media, notice or pointer. With user, the "slug" is the "user ID"