### PR TITLE
Validation callback does not run on an empty field

### DIFF
--- a/includes/class-piklist-validate.php
+++ b/includes/class-piklist-validate.php
@@ -735,7 +735,7 @@ class Piklist_Validate
         $index++;
       }
     }
-    elseif ($field['request_value'])
+    else
     {
       $validation_result = call_user_func_array($validation['callback'], array(0, $field['request_value'], $options, $field, $fields_data));
 


### PR DESCRIPTION
I have had to make this tweak in this class on a few sites now where we have written validation rules which check that at least X number of fields have been filled in but some can be left blank. The original code does not run because in the validation class in the piklist core it checks that the field has a value first. I don't think this is needed. 

Please see our earlier conversation on this some time ago..

https://piklist.com/support/topic/validate-empty-field/

Great to see this now on Github so we can put forward propose tweaks!