### PR TITLE
Use WordPress defaults for register_post_status except 'show_in_admin_status_list'

### DIFF
--- a/includes/class-piklist-cpt.php
+++ b/includes/class-piklist-cpt.php
@@ -192,23 +192,10 @@ class Piklist_CPT
           $status_data['label_count'] = _n_noop($status_data['label'] . ' <span class="count">(%s)</span>', $status_data['label'] . ' <span class="count">(%s)</span>');
           $status_data['capability_type'] = $post_type;
 
+		  // Use WordPress defaults for register_post_status
+		  // except 'show_in_admin_status_list' for backwards compatibility
           $status_data = wp_parse_args($status_data, array(
-            'label' => false
-            ,'label_count' => false
-            ,'exclude_from_search' => null
-            ,'capability_type' => 'post'
-            ,'hierarchical' => false
-            ,'public' => true
-            ,'internal' => null
-            ,'has_archive' => false
-            ,'protected' => true
-            ,'private' => null
-            ,'show_in_admin_all' => null
-            ,'publicly_queryable' => null
-            ,'show_in_admin_status_list' => true
-            ,'show_in_admin_all_list' => true
-            ,'single_view_cap' => null
-            ,'_builtin' => false
+			'show_in_admin_status_list' => true
           ));
 
           $status_data = (object) $status_data;


### PR DESCRIPTION
I suggest we use the WordPress defaults for register_post_status when registering custom statuses in Piklist. EXCEPT 'show_in_admin_status_list'. WordPress sets this to `null` by default, and we currently have it set to `true`:
https://build.trac.wordpress.org/browser/tags/4.9.5/wp-includes/post.php#L792

If we go with the WordPress default of `null`, posts may disappear from list tables around the world for users that did not use that parameter when registering their custom statuses. Leaving this for backwards compatibility.