### PR TITLE
Fix version checking for upgrades

### DIFF
--- a/includes/class-piklist-admin.php
+++ b/includes/class-piklist-admin.php
@@ -113,7 +113,7 @@ class Piklist_Admin
    */
   public static function init()
   {
-    $data = piklist::get_file_data(piklist::$add_ons['piklist']['path'] . '/piklist.php', array(
+    $data = get_file_data(piklist::$add_ons['piklist']['path'] . '/piklist.php', array(
               'version' => 'Version'
             ));
 


### PR DESCRIPTION
There's a bug wherein the version stored in the options table for plugins is casted as a number of numeric. So 0.10, for example, becomes 0.1. In versioning these are not the same.