### PR TITLE
Allow user with no role set to save

### DIFF
--- a/includes/class-piklist-form.php
+++ b/includes/class-piklist-form.php
@@ -1604,7 +1604,7 @@ class Piklist_Form
       ,'valid' => true
       ,'new' => false
 
-      ,'capability' => null
+      ,'capability' => 'none'
       ,'role' => 'none'
       ,'logged_in' => false
       ,'on_post_status' => array()
@@ -2149,7 +2149,7 @@ class Piklist_Form
     {
       case 'capability':
 
-        return piklist_user::current_user_can($value);
+        return $value == 'none' ? true : piklist_user::current_user_can($value);
 
       break;
 

--- a/includes/class-piklist-form.php
+++ b/includes/class-piklist-form.php
@@ -1605,7 +1605,7 @@ class Piklist_Form
       ,'new' => false
 
       ,'capability' => null
-      ,'role' => null
+      ,'role' => 'none'
       ,'logged_in' => false
       ,'on_post_status' => array()
       ,'redirect' => null
@@ -2155,7 +2155,7 @@ class Piklist_Form
 
       case 'role':
 
-        return piklist_user::current_user_role($value);
+        return $value == 'none' ? true : piklist_user::current_user_role($value);
 
       break;
 

--- a/includes/class-piklist-form.php
+++ b/includes/class-piklist-form.php
@@ -1604,8 +1604,8 @@ class Piklist_Form
       ,'valid' => true
       ,'new' => false
 
-      ,'capability' => 'none'
-      ,'role' => 'none'
+      ,'capability' => null
+      ,'role' => null
       ,'logged_in' => false
       ,'on_post_status' => array()
       ,'redirect' => null
@@ -2149,13 +2149,13 @@ class Piklist_Form
     {
       case 'capability':
 
-        return 'none' === $value ? true : piklist_user::current_user_role($value);
+        return null === $value ? true : piklist_user::current_user_can($value);
 
       break;
 
       case 'role':
 
-        return 'none' === $value ? true : piklist_user::current_user_role($value);
+        return null === $value ? true : piklist_user::current_user_role($value);
 
       break;
 
@@ -3196,7 +3196,7 @@ class Piklist_Form
           {
             $paths = piklist::array_paths($_FILES[piklist::$prefix . $scope]['name'][$field['field']]);
 
-            $allowed = $field['role'] == 'none' || $field['capability'] == 'none' || current_user_can('upload_files');
+            $allowed = $field['role'] === null || $field['capability'] === null || current_user_can('upload_files');
 
             if (!$allowed)
             {
@@ -3277,7 +3277,7 @@ class Piklist_Form
         $objects = array();
         foreach ($fields as &$field)
         {
-          $allowed = $field['role'] == 'none' || $field['capability'] == 'none';
+          $allowed = $field['role'] === null || $field['capability'] === null;
           $context = self::get_field_context($field);
 
           if (!$allowed)
@@ -3464,7 +3464,7 @@ class Piklist_Form
             }
           }
 
-          $allowed = $field['role'] == 'none' || $field['capability'] == 'none';
+          $allowed = $field['role'] === null || $field['capability'] === null;
 
           if (!$allowed)
           {
@@ -3727,7 +3727,7 @@ class Piklist_Form
       {
         foreach ($fields as &$field)
         {
-          $allowed = $field['role'] == 'none' || $field['capability'] == 'none';
+          $allowed = $field['role'] === null || $field['capability'] === null;
 
           if (!$allowed)
           {

--- a/includes/class-piklist-form.php
+++ b/includes/class-piklist-form.php
@@ -2149,13 +2149,13 @@ class Piklist_Form
     {
       case 'capability':
 
-        return $value == 'none' ? true : piklist_user::current_user_can($value);
+        return 'none' === $value ? true : piklist_user::current_user_role($value);
 
       break;
 
       case 'role':
 
-        return $value == 'none' ? true : piklist_user::current_user_role($value);
+        return 'none' === $value ? true : piklist_user::current_user_role($value);
 
       break;
 

--- a/includes/class-piklist-form.php
+++ b/includes/class-piklist-form.php
@@ -2149,13 +2149,13 @@ class Piklist_Form
     {
       case 'capability':
 
-        return null === $value ? true : piklist_user::current_user_can($value);
+        return empty($value) || piklist_user::current_user_can($value);
 
       break;
 
       case 'role':
 
-        return null === $value ? true : piklist_user::current_user_role($value);
+        return empty($value) || piklist_user::current_user_role($value);
 
       break;
 

--- a/piklist.php
+++ b/piklist.php
@@ -3,7 +3,7 @@
 Plugin Name: Piklist
 Plugin URI: https://piklist.com
 Description: The most powerful framework available for WordPress.
-Version: 0.11.4
+Version: 0.11.5
 Author: Piklist
 Author URI: https://piklist.com
 Text Domain: piklist

--- a/readme.txt
+++ b/readme.txt
@@ -148,6 +148,10 @@ Thank you for wanting to contribute! It helps everyone out!
 
 == Changelog ==
 
+= 0.11.5 =
+
+* ENHANCED: Allow user with no role set to save
+
 = 0.11.4 =
 Release Date: June 11, 2018
 


### PR DESCRIPTION
This allows developers to have forms that a non-logged in user can post content to (e.g. contact forms).

It seems we already have code for the user role and capability 'none' in Piklist, that's why this works:

https://github.com/piklist/piklist/blob/develop/includes/class-piklist-form.php#L3199

https://github.com/piklist/piklist/blob/develop/includes/class-piklist-form.php#L3280

https://github.com/piklist/piklist/blob/develop/includes/class-piklist-form.php#L3467

https://github.com/piklist/piklist/blob/develop/includes/class-piklist-form.php#L3730



