### PR TITLE
when saving user data, check if $_GET['user_id'] is set before validating user

### DIFF
--- a/includes/class-piklist.php
+++ b/includes/class-piklist.php
@@ -1093,7 +1093,7 @@ class Piklist
       $validate_object = 'term';
     }
 
-    if ( $pagenow == 'user-edit.php' )
+    if ( $pagenow == 'user-edit.php' & isset($_GET['user_id']))
     {
       $user = get_user_by('id', $_GET['user_id']);
       $validate_object = 'user';

--- a/readme.txt
+++ b/readme.txt
@@ -150,6 +150,7 @@ Thank you for wanting to contribute! It helps everyone out!
 
 = 0.11.5 =
 
+* FIXED: when saving user data, check if $_GET['user_id'] is set before validating user.
 * ENHANCED: Allow user with no role set to save
 
 = 0.11.4 =


### PR DESCRIPTION
When saving user data on a page like this:
/wp-admin/user-edit.php?user_id=5

WordPress first redirects the page to:
/wp-admin/user-edit.php

which temporarily removes the query parameter from the url and throws a notice.