### PR TITLE
move into isset($active['parts'] check

### DIFF
--- a/parts/shared/admin-workflow.php
+++ b/parts/shared/admin-workflow.php
@@ -1,6 +1,8 @@
 <div class="wrap piklist-workflow <?php echo $position == 'header' ? 'piklist-workflow-position-header' : null; ?>">
 
-  <?php 
+  <?php $sub_page_active = false; ?>
+
+  <?php
     foreach ($workflows as $tab):
       if ($tab['data']['header']):
         piklist::render($tab['part'], array(
@@ -8,28 +10,28 @@
         ));
       endif;
     endforeach;
-    
+
     $tabs_to_render = 0;
     foreach ($workflows as $workflow):
       $tabs_to_render = !$workflow['data']['header'] ? $tabs_to_render + 1 : $tabs_to_render;
     endforeach;
-    
+
     if ($tabs_to_render > 1 || ($tabs_to_render == 1 && isset($active['parts']) && count($active['parts']) > 1)):
   ?>
-    
+
     <?php if ($layout == 'bar'): ?>
-      
+
       <div class="wp-filter">
-        
+
         <ul class="filter-links">
-  
+
     <?php else: ?>
-    
+
       <h2 class="nav-tab-wrapper piklist-workflow-tab-wrapper">
 
     <?php endif; ?>
-    
-        <?php 
+
+        <?php
 
           foreach ($workflows as $tab):
             if (!$tab['data']['header']):
@@ -43,70 +45,73 @@
         ?>
 
     <?php if ($layout == 'bar'): ?>
-      
+
         </ul>
-    
+
         <?php do_action('piklist_workflow_flow_append', $tab['data']['flow_slug']); ?>
-        
+
       </div>
-  
+
     <?php else: ?>
-      
+
         <?php do_action('piklist_workflow_flow_append', $tab['data']['flow_slug']); ?>
-      
+
       </h2>
 
     <?php endif; ?>
-    
+
     <?php if (isset($active['parts'])): ?>
 
       <ul class="subsubsub piklist-workflow-subsubsub">
-      
+
         <?php foreach ($active['parts'] as $order => $part): ?>
-        
+
           <li class="nav-tab-sub"><a <?php echo $part['url'] ? 'href="' . esc_url($part['url']) . '"' : null; ?> class="<?php echo $part['data']['active'] ? 'current' : null; ?>"><?php _e($part['data']['title']); ?></a> <?php echo $part === end($active['parts']) ? null : '|'; ?></li>
 
         <?php endforeach; ?>
-  
-      </ul>
-    
-      <div class="clear"></div>
-  
-    <?php endif; ?>
-  
-  <?php endif; ?>
-  
-  <?php
-    $sub_page_active = false;
-    
-    foreach ($active['parts'] as $order => $part):
-      if ($part['data']['active']):
 
-        do_action('piklist_pre_render_workflow', $part);
-    
-        piklist::render($part['part'], array(
-          'data' => $part['data']
-        ));
-    
-        do_action('piklist_post_render_workflow', $part);
-        
-        $sub_page_active = true;
-        
-        break;
-        
-      endif;
-    endforeach;
-    
+      </ul>
+
+      <div class="clear"></div>
+
+    <?php endif; ?>
+
+    <?php
+
+      foreach ($active['parts'] as $order => $part):
+        if ($part['data']['active']):
+
+          do_action('piklist_pre_render_workflow', $part);
+
+          piklist::render($part['part'], array(
+            'data' => $part['data']
+          ));
+
+          do_action('piklist_post_render_workflow', $part);
+
+          $sub_page_active = true;
+
+          break;
+
+        endif;
+      endforeach;
+
+     ?>
+
+  <?php endif; ?>
+
+  <?php
+
     if (!$sub_page_active):
-      
+
       do_action('piklist_pre_render_workflow', $active);
-    
+
       piklist::render($active['part'], array(
         'data' => $active
       ));
-    
+
       do_action('piklist_post_render_workflow', $active);
-    
+
     endif;
   ?>
 


### PR DESCRIPTION
ISSUE:
$active['parts'] is only set when a workflow has subtabs set. On pages with no subtabs, like `wp-admin/admin.php?page=piklist-core-settings` you get a warning.

SOLUTION:
Move the `foreach ($active['parts'] as $order => $part):` loop into the `if (isset($active['parts'])):` check

TEST:
You can test by visiting any workflow page with subtabs, and `wp-admin/admin.php?page=piklist-core-settings`