### PR TITLE
Add post_id in a WHERE clause to speed up DISTINCT query.

### DIFF
--- a/includes/class-piklist-revision.php
+++ b/includes/class-piklist-revision.php
@@ -27,7 +27,7 @@ class Piklist_Revision
     add_action('save_post', array('piklist_revision', 'save_post'), 10, 2);
     add_action('wp_restore_post_revision', array('piklist_revision', 'restore_revision'), 10, 2);
 
-    add_filter('_wp_post_revision_fields', array('piklist_revision', 'wp_post_revision_fields'));
+    add_filter('_wp_post_revision_fields', array('piklist_revision', 'wp_post_revision_fields'), 10, 2);
   }
 
   /**
@@ -95,6 +95,7 @@ class Piklist_Revision
    * Adds a custom field for metadata to the revision ui.
    *
    * @param array $fields The current set of fields for the ui.
+   * @param array $post   Current post data as array. Added in WordPress 4.5.0
    *
    * @return array Updated fields.
    *
@@ -102,11 +103,16 @@ class Piklist_Revision
    * @static
    * @since 1.0
    */
-  public static function wp_post_revision_fields($fields)
+  public static function wp_post_revision_fields($fields, $post = array())
   {
     global $wpdb;
 
-    $meta_keys = $wpdb->get_col("SELECT DISTINCT meta_key FROM $wpdb->postmeta");
+    if (empty($post)) {
+      $post = get_post($post, ARRAY_A);
+    }
+    $post_id = absint($post['ID']);
+
+    $meta_keys = $wpdb->get_col("SELECT DISTINCT meta_key FROM $wpdb->postmeta WHERE post_id=$post_id");
 
     foreach ($meta_keys as $meta_key)
     {

--- a/includes/class-piklist-revision.php
+++ b/includes/class-piklist-revision.php
@@ -112,7 +112,8 @@ class Piklist_Revision
     }
     $post_id = absint($post['ID']);
 
-    $meta_keys = $wpdb->get_col("SELECT DISTINCT meta_key FROM $wpdb->postmeta WHERE post_id=$post_id");
+    $query     = $wpdb->prepare("SELECT DISTINCT meta_key FROM $wpdb->postmeta WHERE post_id=%d", $post_id);
+    $meta_keys = $wpdb->get_col($query);
 
     foreach ($meta_keys as $meta_key)
     {


### PR DESCRIPTION
Using `post_id` in a `WHERE` clause speeds up the `DISTINCT` query by ~50-70% in my profiling with a million rows postmeta table.

Uses `$post` param (added in WordPress 4.5.0), if available, otherwise uses global `$post` object through `get_post()`.

One edge case that I could think of is when a new meta is added to post. This meta maybe already applied to other posts of similar types so the `meta_key` would be there in the postmeta table. But by adding `WHERE` clause we will not know about it until that meta is updated in future for this post.

Another solution is to cache the current `DISTINCT` query in a transient and invalidate it by hooking into `added_post_meta`.

See #115