### PR TITLE
Making sure the post saves if no TinyMCE was found

### DIFF
--- a/parts/js/admin.js
+++ b/parts/js/admin.js
@@ -432,10 +432,12 @@
         if (!wp.autosave)
         {
           var editor = tinyMCE.activeEditor;
+          
+          if (editor) {
+            editor.selection.select(editor.getBody(), true);
+            editor.selection.collapse(true);
+          }
 
-          editor.selection.select(editor.getBody(), true);
-
-          editor.selection.collapse(true);
         }
       });
 


### PR DESCRIPTION
Making sure the post saves if no TinyMCE was found on the page. For example, when a Frontend Editor mode is used in WPBakery Visual Composer Page editor together with Piklist, the post does not save and the following error gets triggered:

```
admin.js?ver=1.0.4:436 Uncaught TypeError: Cannot read property 'selection' of null
    at HTMLDocument.<anonymous> (admin.js?ver=1.0.4:436)
    at HTMLDocument.dispatch (load-scripts.php?c=0&load[]=jquery-core,jquery-migrate,utils,moxiejs,plupload&ver=5.2:3)
    at HTMLDocument.r.handle (load-scripts.php?c=0&load[]=jquery-core,jquery-migrate,utils,moxiejs,plupload&ver=5.2:3)
    at Object.trigger (load-scripts.php?c=0&load[]=jquery-core,jquery-migrate,utils,moxiejs,plupload&ver=5.2:3)
    at Object.a.event.trigger (load-scripts.php?c=0&load[]=jquery-core,jquery-migrate,utils,moxiejs,plupload&ver=5.2:8)
    at HTMLBodyElement.<anonymous> (load-scripts.php?c=0&load[]=jquery-core,jquery-migrate,utils,moxiejs,plupload&ver=5.2:3)
    at Function.each (load-scripts.php?c=0&load[]=jquery-core,jquery-migrate,utils,moxiejs,plupload&ver=5.2:2)
    at a.fn.init.each (load-scripts.php?c=0&load[]=jquery-core,jquery-migrate,utils,moxiejs,plupload&ver=5.2:2)
    at a.fn.init.trigger (load-scripts.php?c=0&load[]=jquery-core,jquery-migrate,utils,moxiejs,plupload&ver=5.2:3)
    at Object.u [as pre_wpautop] (editor.min.js?ver=5.2:1)
```