### PR TITLE
FIXED: PHP 7.4 notice for Dashboard / CPT meta boxes

### DIFF
--- a/includes/class-piklist-meta.php
+++ b/includes/class-piklist-meta.php
@@ -349,7 +349,7 @@ class Piklist_Meta
         {
           foreach ($wp_meta_boxes[$current_screen->id][$context][$priority] as $meta_box)
           {
-            if ($meta_box['id'] == $part['id'] && (!isset($part['data']['post_type']) || ($part['data']['post_type'] && in_array($current_screen->id, $part['data']['post_type']))))
+			if (!empty($meta_box['id']) && !empty($part['id']) && $meta_box['id'] == $part['id'] && (!isset($part['data']['post_type']) || ($part['data']['post_type'] && in_array($current_screen->id, $part['data']['post_type']))))
             {
               if (is_array($part['render']) && !in_array($meta_box, $part['render']))
               {

--- a/piklist.php
+++ b/piklist.php
@@ -3,7 +3,7 @@
 Plugin Name: Piklist
 Plugin URI: https://piklist.com
 Description: The most powerful framework available for WordPress.
-Version: 1.0.9
+Version: 1.0.10
 Author: Piklist
 Author URI: https://piklist.com
 Text Domain: piklist

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: piklist, p51labs, sbruner, jason_the_adams
 Tested up to: 4.9
 Requires at least: 4.0
-Stable tag: 1.0.9
+Stable tag: 1.0.10
 Requires PHP: 5.3
 Tags: custom field, custom fields, forms, framework, flexible, content, meta boxes, post types, repeater, advanced
 Donate link: http://piklist.com/get-involved/
@@ -150,6 +150,11 @@ Thank you for wanting to contribute! It helps everyone out!
 4. Ask questions on our <a href="https://piklist.com/support/">Support Forum</a>. (We love hearing from our users)
 
 == Changelog ==
+
+= 1.0.10 =
+Release Date: September 9, 2020
+
+* FIXED: PHP 7.4 notice for Dashboard / CPT meta boxes
 
 = 1.0.9 =
 Release Date: July 6, 2020


### PR DESCRIPTION
check if !empty($meta_box['id']) && !empty($part['id'].

Was throwing this error in PHP 7.4
`Notice: Trying to access array offset on value of type null in /var/www/example.com/public_html/wp-content/plugins/piklist/includes/class-piklist-meta.php`